### PR TITLE
Fix resource leak in Apache client test

### DIFF
--- a/src/test/java/io/learning/TestWithAllAPIClients.java
+++ b/src/test/java/io/learning/TestWithAllAPIClients.java
@@ -86,19 +86,20 @@ public class TestWithAllAPIClients {
     @Test
     void testWithApacheHttpClient() throws ProtocolException, IOException {
         // prepare request
-        CloseableHttpClient httpClient = HttpClients.createDefault();
-        HttpGet request = new HttpGet(this.URL);
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet request = new HttpGet(this.URL);
 
-        // send request
-        CloseableHttpResponse response = httpClient.execute(request);
+            // send request
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
 
-        // validate response
-        assertEquals(200, response.getCode());
-        assertEquals(CONTENT_TYPE_VALUE,
-                response.getHeader(CONTENT_TYPE_KEY).getValue());
-        assertTrue(EntityUtils.toString(response.getEntity())
-                .contains(LEANNE_GRAHAM));
-        httpClient.close();
+                // validate response
+                assertEquals(200, response.getCode());
+                assertEquals(CONTENT_TYPE_VALUE,
+                        response.getHeader(CONTENT_TYPE_KEY).getValue());
+                assertTrue(EntityUtils.toString(response.getEntity())
+                        .contains(LEANNE_GRAHAM));
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- close `CloseableHttpResponse` using try-with-resources
- ensure `CloseableHttpClient` is closed automatically

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684283995bb8832681dfe8f1b1b2b8ab