### PR TITLE
Rename REST Assured test method

### DIFF
--- a/src/test/java/io/learning/TestWithAllAPIClients.java
+++ b/src/test/java/io/learning/TestWithAllAPIClients.java
@@ -135,7 +135,7 @@ public class TestWithAllAPIClients {
     }
 
     @Test
-    void testWithRESTAssured() {
+    void testWithRestAssured() {
         given().
                 baseUri(this.URL).       // prepare request
         when()


### PR DESCRIPTION
## Summary
- rename `testWithRESTAssured` to `testWithRestAssured`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842986749f08326a2bea7451726d1a9