### PR TITLE
Replace JDK assert with assertNotNull

### DIFF
--- a/src/test/java/io/learning/TestWithAllAPIClients.java
+++ b/src/test/java/io/learning/TestWithAllAPIClients.java
@@ -125,7 +125,7 @@ public class TestWithAllAPIClients {
                 .block();
 
         // validate response
-        assert response != null;
+        assertNotNull(response);
         assertEquals(HttpStatus.OK, response.statusCode());
         assertEquals("application/json;charset=utf-8",
                 Objects.requireNonNull(response.headers().asHttpHeaders().getContentType())


### PR DESCRIPTION
## Summary
- use `assertNotNull` in the `testWithSpringWebClient` method

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429942b28c8326b7aec13bb2f819f6